### PR TITLE
Fix script needlessly failing due to `~/.local/share/fonts` not exist…

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -86,7 +86,10 @@ distro_detect() {
 	   ;;
 	*)
 	   distro="$(source /etc/os-release && echo "${PRETTY_NAME}")"
-	   if [ ! -f /usr/share/fonts/Material.ttf ];then
+       if [ ! -d $HOME/.local/share/fonts ]; then
+        mkdir -p $HOME/.local/share/fonts
+       fi
+	   if [ ! -f $HOME/.local/share/fonts/Material.ttf ] && [ ! -f /usr/share/fonts/Material.ttf ]; then
 		cp -r ttf-material-design-icons/* $HOME/.local/share/fonts
 		fc-cache -vf &>/dev/null
 	   fi


### PR DESCRIPTION
…ing and severe slowdown caused by script checking entire `/usr/share/fonts` directory and not checking the directory it literally installs the font to first