### PR TITLE
Added gentoo support for listing packages and corrected the openrc misidentifying

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -67,7 +67,7 @@ net_pkg() {
 	 total=$(rpm -qa | wc -l)
 	 ;;
       "emerge")
-     total=$(qlist -I | wc -l)
+	 total=$(qlist -I | wc -l)
      ;;
 #      "dpkg")
 #	 total=$(dpkg-query -l | wc -l)

--- a/rxfetch
+++ b/rxfetch
@@ -68,7 +68,7 @@ net_pkg() {
 	 ;;
       "emerge")
 	 total=$(qlist -I | wc -l)
-     ;;
+	 ;;
 #      "dpkg")
 #	 total=$(dpkg-query -l | wc -l)
 #	 ;;

--- a/rxfetch
+++ b/rxfetch
@@ -25,13 +25,17 @@ c8="${black}"
 c9="${bgyellow}"
 c10="${bgwhite}"
 
-#getting the init 
+#getting the init
 get_init() {
     os="$(uname -o)"
     if [[ "$os" = "Android" ]]; then
        echo "init.rc"
     elif [[ ! $(pidof systemd) ]]; then
+        if [[ -f "/sbin/openrc" ]]; then
+            echo "openrc"
+        else
          echo $(cat /proc/1/comm)
+        fi
     else
         echo "systemD"
     fi
@@ -39,7 +43,7 @@ get_init() {
 
 #get total packages
 net_pkg() {
-    pack="$(which {xbps-install,apk,apt,pacman,nix,yum,rpm,dpkg} 2>/dev/null | grep -v "not found" | awk -F/ 'NR==1{print $NF}')"
+    pack="$(which {xbps-install,apk,apt,pacman,nix,yum,rpm,dpkg,emerge} 2>/dev/null | grep -v "not found" | awk -F/ 'NR==1{print $NF}')"
   case "${pack}" in
       "xbps-install")
 	 total=$(xbps-query -l | wc -l)
@@ -62,6 +66,9 @@ net_pkg() {
       "rpm")
 	 total=$(rpm -qa | wc -l)
 	 ;;
+      "emerge")
+     total=$(qlist -I | wc -l)
+     ;;
 #      "dpkg")
 #	 total=$(dpkg-query -l | wc -l)
 #	 ;;


### PR DESCRIPTION
I like rxfetch but when I ran it on my gentoo system, I noticed that it has not counted the packages and the init system was 'init'.

I have fixed both of these issues and now rxfetch will count the packages on gentoo correctly and will display the correct init system. To count the packages, the emerge command can not do this natively, but I have used another utility found in the default installation of gentoo to count packages.