### PR TITLE
change yum to dnf

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -43,7 +43,7 @@ get_init() {
 
 #get total packages
 net_pkg() {
-    pack="$(which {xbps-install,apk,apt,pacman,nix,yum,rpm,dpkg,emerge} 2>/dev/null | grep -v "not found" | awk -F/ 'NR==1{print $NF}')"
+    pack="$(which {xbps-install,apk,apt,pacman,nix,dnf,rpm,dpkg,emerge} 2>/dev/null | grep -v "not found" | awk -F/ 'NR==1{print $NF}')"
   case "${pack}" in
       "xbps-install")
 	 total=$(xbps-query -l | wc -l)
@@ -60,8 +60,8 @@ net_pkg() {
       "nix")
 	 total=$(nix-env -qa --installed "*" | wc -l)
 	 ;;
-      "yum")
-	 total=$(yum list installed | wc -l)
+      "dnf")
+	 total=$(dnf list installed | wc -l)
 	 ;;
       "rpm")
 	 total=$(rpm -qa | wc -l)


### PR DESCRIPTION
changing to dnf from yum for fedora systems because dnf is used more now as compared to yum and also its the main stream package manager in fedora.

Works fine on fedora distros:

![image](https://user-images.githubusercontent.com/48408336/127777842-11e84de8-f4f4-4092-a876-ea9a4ae061fa.png)

ps: don't mind the material font as I didn't install at that time

