### PR TITLE
fix: make pidof command run silently

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -30,7 +30,7 @@ get_init() {
 	os=$(uname -o)
 	if [[ $os = Android ]]; then
 		varInit="init.rc"
-	elif ! pidof systemd; then
+	elif ! pidof -q systemd; then
 		if [[ -f "/sbin/openrc" ]]; then
 			varInit="openrc"
 		else


### PR DESCRIPTION
I recently installed this package and after running it I found that the very first output line was a meaningless number. After debugging it I was able to tell that the number shown was the PID of the systemd process, I added the -q flag to hide pidof output.