### PR TITLE
"systemd" doesn't cointain any capitalized letter

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -37,7 +37,7 @@ get_init() {
 			read -r varInit < /proc/1/comm
 		fi
 	else
-		varInit="systemD"
+		varInit="systemd"
 	fi
 }
 


### PR DESCRIPTION
It uses <name_of_service> + d naming, just like ircd, snapd, etc...