### PR TITLE
fixing apt from java conflict

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -63,7 +63,12 @@ get_pkg_count() {
 			case "$package_manager" in
 			xbps-install) xbps-query -l | wc -l ;;
 			apk) apk search | wc -l ;;
-			apt) echo $(($(apt list --installed 2>/dev/null | wc -l) - 1)) ;;
+			apt) if [ "$kernel" != "Darwin" ]; then 
+					echo $(($(apt list --installed 2>/dev/null | wc -l) - 1))
+				 else
+					echo 0
+				 fi
+				 ;;
 			pacman) pacman -Q | wc -l ;;
 			nix) nix-env -qa --installed '*' | wc -l ;;
 			dnf) dnf list installed | wc -l ;;


### PR DESCRIPTION
<img width="879" alt="image" src="https://user-images.githubusercontent.com/86282911/198532284-b92019ba-036c-46a3-b4f6-217a48698ea6.png">

this was conflicting with the linux apt. Doesn't anymore.