### PR TITLE
fix detection of non-wemh window managers

### DIFF
--- a/rxfetch
+++ b/rxfetch
@@ -228,19 +228,15 @@ get_de_wm() {
 	}
 
 	# for non-EWMH WMs
-	[ ! "$wm" ] || [ "$wm" = "LG3D" ] &&
-		wm=$(pgrep -m 1 -o \
-			-e "sway" \
-			-e "kiwmi" \
-			-e "wayfire" \
-			-e "sowm" \
-			-e "catwm" \
-			-e "fvwm" \
-			-e "dwm" \
-			-e "2bwm" \
-			-e "monsterwm" \
-			-e "tinywm" \
-			-e "xmonad")
+	[ ! "$wm" ] || [ "$wm" = "LG3D" ] && {
+		wms=('sway' 'kiwmi' 'wayfire' 'sowm' 'catwm' 'fvwm' 'dwm' '2bwm' 'monsterwm' 'tinywm' 'xmonad')
+		for current_wm in "${wms[@]}"; do
+			if pgrep -x "$current_wm" 2>/dev/null >&2; then
+				wm="${current_wm}";
+				break
+			fi
+		done
+	}
 
 	echo "${wm:-unknown}"
 }


### PR DESCRIPTION
I dont know of any version of pgrep that supports the -m and -e options.
I suppose that those flags have a strong relation with the grep ones,
-m N used to stop after N matches and -e PATTERN to match a lot of
different patterns.
So this is a patch to stop depending on those options, simply by
iterating over all the possible window managers and doing a pgrep on
each one until we find the one that is running.

This fixes #51